### PR TITLE
Fix/nodename check

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -45,6 +45,8 @@ kubectl apply -f multi-networkpolicy-iptables/demo/alpine.yml
 
 You can the log in to the alpine pod and check the
 [iptables rules](demo/iptables.log) that are enforcing the policy:
+(note: this rule might be different from yours because we may change iptable generation rules...)
+
 ```
 kubectl exec -ti alpine -- /bin/sh
 ...

--- a/pkg/controllers/pod.go
+++ b/pkg/controllers/pod.go
@@ -28,6 +28,7 @@ import (
 	docker "github.com/docker/docker/client"
 	netdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	netdefutils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
+	multiutils "github.com/k8snetworkplumbingwg/multi-networkpolicy-iptables/pkg/utils"
 
 	"google.golang.org/grpc"
 
@@ -319,11 +320,13 @@ func (pct *PodChangeTracker) newPodInfo(pod *v1.Pod) (*PodInfo, error) {
 
 	// get container network namespace
 	netnsPath := ""
-	if pct.hostname == pod.Spec.NodeName {
+	klog.V(8).Infof("pod:%s/%s, %s %s", pod.Namespace, pod.Name, pct.hostname, pod.Spec.NodeName)
+	if multiutils.CheckNodeNameIdentical(pct.hostname, pod.Spec.NodeName) {
 		netnsPath, err = pct.getPodNetNSPath(pod)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get pod network namespace: %v", err)
 		}
+		klog.V(8).Infof("NetnsPath: %s", netnsPath)
 	}
 
 	// netdefname -> plugin name map

--- a/pkg/utils/node.go
+++ b/pkg/utils/node.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"strings"
+)
+
+// CheckIdenticalNodeNameIdentical checks both strings point a same node
+// it just checks hostname without domain
+func CheckNodeNameIdentical(s1, s2 string) bool {
+	return strings.Split(s1, ".")[0] == strings.Split(s2, ".")[0]
+}


### PR DESCRIPTION
In some case, pod node name may contain domain name hence need to remove it to match hostname. This fix changes the node name check to ignore domain name.