### PR TITLE
Remove alpine container to stopping pod restart

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -84,20 +84,6 @@ spec:
         effect: NoSchedule
       serviceAccountName: multi-networkpolicy
       containers:
-      - image: alpine:3.2
-        command:
-        - /bin/sh
-        - "-c"
-        - "sleep 60m"
-        imagePullPolicy: IfNotPresent
-        name: alpine
-        securityContext:
-          privileged: true
-          capabilities:
-            add: ["SYS_ADMIN", "SYS_NET_ADMIN"]
-        volumeMounts:
-        - name: host
-          mountPath: /host
       - name: multi-networkpolicy
         # crio support requires multus:latest for now. support 3.3 or later.
         image: docker.io/nfvpe/multi-networkpolicy-iptables:snapshot-amd64


### PR DESCRIPTION
Alpine container stops after 60min then kubernetes will restart
multi-networkpolicy-iptables pod due to container stop. This fix
remove alpine pod to fix the issue.