### PR TITLE
Add pod-iptables option to store pod iptables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
         run: go get github.com/mattn/goveralls
 
       - name: install golint
-        run: go get -u golang.org/x/lint/golint
+        run: GOBIN=$(pwd)/bin go get golang.org/x/lint/golint
 
       - name: golint
-        run: golint ./... | grep -v vendor | grep -v ALL_CAPS | xargs -r false
+        run: ./bin/golint ./... | grep -v vendor | grep -v ALL_CAPS | xargs -r false
 
       - name: gofmt
         run: go fmt ./...

--- a/deploy.yml
+++ b/deploy.yml
@@ -95,6 +95,8 @@ spec:
         #- "--container-runtime=docker"
         # change this if runtime is different that crio default
         - "--container-runtime-endpoint=/run/crio/crio.sock"
+        # uncomment this if you want to store iptables rules
+        - "--pod-iptables=/var/lib/multi-networkpolicy/iptables"
         resources:
           requests:
             cpu: "100m"
@@ -109,7 +111,12 @@ spec:
         volumeMounts:
         - name: host
           mountPath: /host
+        - name: var-lib-multinetworkpolicy
+          mountPath: /var/lib/multi-networkpolicy
       volumes:
         - name: host
           hostPath:
             path: /
+        - name: var-lib-multinetworkpolicy
+          hostPath:
+            path: /var/lib/multi-networkpolicy

--- a/pkg/controllers/networkpolicy.go
+++ b/pkg/controllers/networkpolicy.go
@@ -148,6 +148,7 @@ func (info *PolicyInfo) Name() string {
 	return info.Policy.ObjectMeta.Name
 }
 
+// Namespace ...
 func (info *PolicyInfo) Namespace() string {
 	return info.Policy.ObjectMeta.Namespace
 }

--- a/pkg/controllers/pod_test.go
+++ b/pkg/controllers/pod_test.go
@@ -81,6 +81,9 @@ func NewFakePodWithNetAnnotation(namespace, name, annot, status string) *v1.Pod 
 				{Name: "ctr1", Image: "image"},
 			},
 		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		},
 	}
 }
 
@@ -119,6 +122,9 @@ func NewFakePod(namespace, name string) *v1.Pod {
 			Containers: []v1.Container{
 				{Name: "ctr1", Image: "image"},
 			},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
 		},
 	}
 }

--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -37,6 +37,7 @@ type Options struct {
 	containerRuntime         controllers.RuntimeKind
 	containerRuntimeEndpoint string
 	networkPlugins           []string
+	podIptables              string
 	// errCh is the channel that errors will be sent
 	errCh chan error
 }
@@ -50,8 +51,9 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.Kubeconfig, "kubeconfig", o.Kubeconfig, "Path to kubeconfig file with authorization information (the master location is set by the master flag).")
 	fs.StringVar(&o.master, "master", o.master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
 	fs.StringVar(&o.hostnameOverride, "hostname-override", o.hostnameOverride, "If non-empty, will use this string as identification instead of the actual hostname.")
-	fs.StringVar(&o.hostPrefix, "host-prefix", o.hostnameOverride, "If non-empty, will use this string as prefix for host filesystem.")
+	fs.StringVar(&o.hostPrefix, "host-prefix", o.hostPrefix, "If non-empty, will use this string as prefix for host filesystem.")
 	fs.StringSliceVar(&o.networkPlugins, "network-plugins", []string{"macvlan"}, "List of network plugins to be be considered for network policies.")
+	fs.StringVar(&o.podIptables, "pod-iptables", o.podIptables, "If non-empty, will use this path to store pod's iptables for troubleshooting helper.")
 	fs.AddGoFlagSet(flag.CommandLine)
 }
 

--- a/pkg/server/policyrules_test.go
+++ b/pkg/server/policyrules_test.go
@@ -120,6 +120,9 @@ func NewFakePodWithNetAnnotation(namespace, name, annot, status string, labels m
 				{Name: "ctr1", Image: "image"},
 			},
 		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		},
 	}
 }
 

--- a/pkg/utils/node.go
+++ b/pkg/utils/node.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 )
 
-// CheckIdenticalNodeNameIdentical checks both strings point a same node
+// CheckNodeNameIdentical checks both strings point a same node
 // it just checks hostname without domain
 func CheckNodeNameIdentical(s1, s2 string) bool {
 	return strings.Split(s1, ".")[0] == strings.Split(s2, ".")[0]


### PR DESCRIPTION
This change introduces pod-iptables option to store iptables-rules
in pod's network namespace. This helps administrator/engineer to
troubleshooting.