### PR TITLE
Log filter rules

### DIFF
--- a/pkg/server/policyrules.go
+++ b/pkg/server/policyrules.go
@@ -143,10 +143,6 @@ func (ipt *iptableBuffer) SaveRules(path string) error {
 }
 
 func (ipt *iptableBuffer) SyncRules(iptables utiliptables.Interface) error {
-	if klog.V(6) {
-		klog.Info("restoring rules:", ipt.filterRules.String())
-	}
-
 	return iptables.RestoreAll(ipt.filterRules.Bytes(), utiliptables.NoFlushTables, utiliptables.RestoreCounters)
 }
 

--- a/pkg/server/policyrules.go
+++ b/pkg/server/policyrules.go
@@ -143,11 +143,10 @@ func (ipt *iptableBuffer) SaveRules(path string) error {
 }
 
 func (ipt *iptableBuffer) SyncRules(iptables utiliptables.Interface) error {
-	/*
-		fmt.Fprintf(os.Stderr, "========= filterRules\n")
-		fmt.Fprintf(os.Stderr, "%s", ipt.filterRules.String())
-		fmt.Fprintf(os.Stderr, "=========\n")
-	*/
+	if klog.V(6) {
+		klog.Info("restoring rules:", ipt.filterRules.String())
+	}
+
 	return iptables.RestoreAll(ipt.filterRules.Bytes(), utiliptables.NoFlushTables, utiliptables.RestoreCounters)
 }
 


### PR DESCRIPTION
Logging iptables rules before applying them
can be useful to debug complex scenarios.
Setting verbosity level to 6 as they can be
quite cumbersome.

Signed-off-by: Andrea Panattoni <apanatto@redhat.com>