### PR TITLE
Graceful shutdown for daemonset

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -109,7 +109,7 @@ func (s *Server) RunPodConfig() {
 }
 
 // Run ...
-func (s *Server) Run(hostname string) error {
+func (s *Server) Run(hostname string) {
 	if s.Broadcaster != nil {
 		s.Broadcaster.StartRecordingToSink(
 			&v1core.EventSinkImpl{Interface: s.Client.CoreV1().Events("")})
@@ -140,8 +140,6 @@ func (s *Server) Run(hostname string) error {
 	netdefInformarFactory.Start(wait.NeverStop)
 
 	s.birthCry()
-
-	return nil
 }
 
 func (s *Server) setInitialized(value bool) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -92,7 +92,8 @@ type Server struct {
 	podLister    corelisters.PodLister
 	policyLister multilisterv1beta1.MultiNetworkPolicyLister
 
-	syncRunner *async.BoundedFrequencyRunner
+	syncRunner       *async.BoundedFrequencyRunner
+	syncRunnerStopCh chan struct{}
 }
 
 // RunPodConfig ...
@@ -109,7 +110,7 @@ func (s *Server) RunPodConfig() {
 }
 
 // Run ...
-func (s *Server) Run(hostname string) {
+func (s *Server) Run(hostname string, stopCh chan struct{}) {
 	if s.Broadcaster != nil {
 		s.Broadcaster.StartRecordingToSink(
 			&v1core.EventSinkImpl{Interface: s.Client.CoreV1().Events("")})
@@ -140,6 +141,16 @@ func (s *Server) Run(hostname string) {
 	netdefInformarFactory.Start(wait.NeverStop)
 
 	s.birthCry()
+
+	// Wait for stop signal
+	<-stopCh
+
+	// Stop the sync runner loop
+	s.syncRunnerStopCh <- struct{}{}
+
+	// Delete all iptables by running the `syncMultiPolicy` with no MultiNetworkPolicies
+	s.policyMap = nil
+	s.syncMultiPolicy()
 }
 
 func (s *Server) setInitialized(value bool) {
@@ -161,7 +172,7 @@ func (s *Server) birthCry() {
 
 // SyncLoop ...
 func (s *Server) SyncLoop() {
-	s.syncRunner.Loop(wait.NeverStop)
+	s.syncRunner.Loop(s.syncRunnerStopCh)
 }
 
 // NewServer ...
@@ -273,7 +284,7 @@ func NewServer(o *Options) (*Server, error) {
 	}
 	server.syncRunner = async.NewBoundedFrequencyRunner(
 		"sync-runner", server.syncMultiPolicy, minSyncPeriod, syncPeriod, burstSyncs)
-
+	server.syncRunnerStopCh = make(chan struct{})
 	return server, nil
 }
 
@@ -325,7 +336,7 @@ func (s *Server) OnPodSynced() {
 	s.setInitialized(s.podSynced)
 	s.mu.Unlock()
 
-	s.syncMultiPolicy()
+	s.Sync()
 }
 
 // OnPolicyAdd ...


### PR DESCRIPTION
Graceful shutdown allows cleaning iptable rules in pods.

Open points:
 - pod-iptables logs directory is cleaned during boot. is it necessary to clean it also during shutdown?

This PR also contain a small refactor about `Options` and `Server` interactions.