### PR TITLE
e2e-test: Add script to update server image

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -3,7 +3,7 @@
 
 ### How to test e2e
 
-This requires [Bats](https://github.com/bats-core/bats-core) for test runner. Please instal bats (e.g. dnf, apt and so on).
+This requires [Bats](https://github.com/bats-core/bats-core) for test runner. Please install bats (e.g. dnf, apt and so on).
 
 ```
 $ git clone https://github.com/k8snetworkplumbingwg/multi-networkpolicy-iptables
@@ -19,4 +19,12 @@ $ ./tests/simple-v4-ingress.bats
 $ kind delete cluster
 $ docker kill kind-registry
 $ docker rm kind-registry
+```
+
+### How to deploy server image with new changes
+
+After making changes to the code, it is possible to update the server Daemonset image with the script:
+
+```
+./update_image_on_cluster.sh
 ```

--- a/e2e/update_image_on_cluster.sh
+++ b/e2e/update_image_on_cluster.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -o errexit
+
+E2E="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+export PATH=${PATH}:${E2E}/bin
+OCI_BIN="${OCI_BIN:-docker}"
+IMAGE="localhost:5000/multus-networkpolicy-iptables:e2e"
+
+$OCI_BIN build -t ${IMAGE} ${E2E}/..
+$OCI_BIN push ${IMAGE}
+new_image_with_digest=`${OCI_BIN} inspect --format='{{index .RepoDigests 0}}' ${IMAGE}`
+
+kubectl set image -n kube-system ds/multi-networkpolicy-ds-amd64 multi-networkpolicy=${new_image_with_digest}


### PR DESCRIPTION
Add a script to redeploy the server in the kind cluster. It is useful to quickly test new changes without tearing down the cluster and bringing it up again.

Signed-off-by: Andrea Panattoni <apanatto@redhat.com>