### PR TITLE
Infer PolicyTypes if missing

### DIFF
--- a/e2e/tests/simple-v4-egress-list.bats
+++ b/e2e/tests/simple-v4-egress-list.bats
@@ -21,6 +21,9 @@ setup() {
 	# verify all pods are available
 	run kubectl -n test-simple-v4-egress-list wait --for=condition=ready -l app=test-simple-v4-egress-list pod --timeout=${kubewait_timeout}
 	[ "$status" -eq  "0" ]
+
+	# wait for sync
+	sleep 3
 }
 
 @test "test-simple-v4-egress-list check client-a -> server" {

--- a/e2e/tests/simple-v4-egress.yml
+++ b/e2e/tests/simple-v4-egress.yml
@@ -95,8 +95,6 @@ spec:
   podSelector:
     matchLabels:
       name: pod-server
-  policyTypes:
-  - Egress
   egress:
   - to:
     - podSelector:

--- a/e2e/tests/simple-v4-ingress-list.bats
+++ b/e2e/tests/simple-v4-ingress-list.bats
@@ -21,6 +21,9 @@ setup() {
 	# verify all pods are available
 	run kubectl -n test-simple-v4-ingress-list wait --for=condition=ready -l app=test-simple-v4-ingress-list pod --timeout=${kubewait_timeout}
 	[ "$status" -eq  "0" ]
+
+	# wait for sync
+	sleep 3
 }
 
 @test "test-simple-v4-ingress-list check client-a -> server" {

--- a/e2e/tests/simple-v4-ingress.yml
+++ b/e2e/tests/simple-v4-ingress.yml
@@ -95,8 +95,6 @@ spec:
   podSelector:
     matchLabels:
       name: pod-server
-  policyTypes:
-  - Ingress
   ingress:
   - from:
     - podSelector:

--- a/e2e/tests/simple-v6-ingress-list.bats
+++ b/e2e/tests/simple-v6-ingress-list.bats
@@ -22,6 +22,9 @@ setup() {
 	# verify all pods are available
 	run kubectl -n test-simple-v6-ingress-list wait --for=condition=ready -l app=test-simple-v6-ingress-list pod --timeout=${kubewait_timeout}
 	[ "$status" -eq  "0" ]
+	
+	# wait for sync
+	sleep 3
 }
 
 @test "test-simple-v6-ingress-list check client-a -> server" {


### PR DESCRIPTION
In cases where Spec.PolicyTypes is not specified, it should default to the existence of Ingress or Egress rules.

Updating end2end tests to cover also this scenario.

Changes have been guided by the regular [NetworkPolicy documentation](https://docs.openshift.com/container-platform/4.11/rest_api/network_apis/networkpolicy-networking-k8s-io-v1.html#specification):

> [...] If this field is not specified, it will default based on the existence of Ingress or Egress rules;

