### PR TITLE
Fix end2end tests

### DIFF
--- a/.github/workflows/kind-e2e.yml
+++ b/.github/workflows/kind-e2e.yml
@@ -41,3 +41,15 @@ jobs:
           bats ./tests/ipblock-list.bats
           bats ./tests/simple-v4-ingress-list.bats
           bats ./tests/simple-v4-egress-list.bats
+
+      - name: Export kind logs
+        if: ${{ failure() }}
+        run:
+          ./e2e/bin/kind export logs /tmp/kind-logs
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: kind-logs-e2e
+          path: /tmp/kind-logs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:1.20 as build
 ADD . /usr/src/multi-networkpolicy-iptables
 
 RUN cd /usr/src/multi-networkpolicy-iptables && \
-    go build ./cmd/multi-networkpolicy-iptables/
+    CGO_ENABLED=0 go build ./cmd/multi-networkpolicy-iptables/
 
 FROM centos:centos7
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multi-networkpolicy-iptables

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -4,7 +4,7 @@ FROM openshift/origin-release:golang-1.14 as build
 # Add everything
 ADD . /usr/src/multi-networkpolicy-iptables
 WORKDIR /usr/src/multi-networkpolicy-iptables
-RUN go build ./cmd/multi-networkpolicy-iptables/
+RUN CGO_ENABLED=0 go build ./cmd/multi-networkpolicy-iptables/
 
 FROM registry.access.redhat.com/ubi8/ubi:latest
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multi-networkpolicy-iptables


### PR DESCRIPTION
Flakiness we are experiencing in:
- https://github.com/k8snetworkplumbingwg/multi-networkpolicy-iptables/pull/50

are because of the `multinetwork-policy-iptables` binary is built in `golang:1.20` and run in `centos:centos7`, producing an error like:
```
2023-07-07T08:35:03.719070939Z stderr F /usr/bin/multi-networkpolicy-iptables: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /usr/bin/multi-networkpolicy-iptables)
```

This PR, beside fixing the above error by setting `CGO_ENABLED=0` [1], make kind logs available for debugging purpose in case of test failure.

[1] https://stackoverflow.com/a/64531740
