### PR TITLE
Make sure that policies with no valid peers are enforced

### DIFF
--- a/e2e/tests/ingress-ns-selector-no-pods.bats
+++ b/e2e/tests/ingress-ns-selector-no-pods.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+
+# Note:
+# These test cases verify that an ingress rule on the server that matches no pods 
+# does not allow any pods to reach the server.
+
+setup() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	server_net1=$(get_net1_ip "test-ingress-ns-selector-no-pods" "pod-server")
+	client_a_net1=$(get_net1_ip "test-ingress-ns-selector-no-pods" "pod-client-a")
+	client_b_net1=$(get_net1_ip "test-ingress-ns-selector-no-pods-blue" "pod-client-b")
+}
+
+@test "setup ingress-ns-selector-no-pods test environments" {
+	# create test manifests
+	kubectl create -f ingress-ns-selector-no-pods.yml
+
+	# verify all pods are available
+	run kubectl -n test-ingress-ns-selector-no-pods wait --for=condition=ready -l app=test-ingress-ns-selector-no-pods pod --timeout=${kubewait_timeout}
+	[ "$status" -eq  "0" ]
+
+	sleep 5
+}
+
+@test "test-ingress-ns-selector-no-pods check client-a -> server" {
+	# nc should NOT succeed from client-a to server by policy
+	run kubectl -n test-ingress-ns-selector-no-pods exec pod-client-a -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	[ "$status" -eq  "1" ]
+}
+
+@test "test-ingress-ns-selector-no-pods check client-b -> server" {
+	# nc should NOT succeed from client-b to server by policy
+	run kubectl -n test-ingress-ns-selector-no-pods-blue exec pod-client-b -- sh -c "echo x | nc -w 1 ${server_net1} 5555"
+	[ "$status" -eq  "1" ]
+}
+
+@test "test-ingress-ns-selector-no-pods check server -> client-a" {
+	# nc should succeed from server to client-a by no policy definition for direction (egress for pod-server)
+	run kubectl -n test-ingress-ns-selector-no-pods exec pod-server -- sh -c "echo x | nc -w 1 ${client_a_net1} 5555"
+	[ "$status" -eq  "0" ]
+}
+
+@test "test-ingress-ns-selector-no-pods check server -> client-b" {
+	# nc should succeed from server to client-b by no policy definition for direction (egress for pod-server)
+	run kubectl -n test-ingress-ns-selector-no-pods exec pod-server -- sh -c "echo x | nc -w 1 ${client_b_net1} 5555"
+	[ "$status" -eq  "0" ]
+}
+
+@test "cleanup environments" {
+	# remove test manifests
+	kubectl delete -f ingress-ns-selector-no-pods.yml
+	run kubectl -n test-ingress-ns-selector-no-pods wait --for=delete -l app=test-ingress-ns-selector-no-pods pod --timeout=${kubewait_timeout}
+	[ "$status" -eq  "0" ]
+
+	sleep 3
+	# check that no iptables files in pod-iptables
+	pod_name=$(kubectl -n kube-system get pod -o wide | grep 'kind-worker' | grep multi-net | cut -f 1 -d ' ')
+	run kubectl -n kube-system exec ${pod_name} -- \
+		sh -c "find /var/lib/multi-networkpolicy/iptables/ -name '*.iptables' | wc -l"
+        [ "$output" = "0" ]
+}

--- a/e2e/tests/ingress-ns-selector-no-pods.yml
+++ b/e2e/tests/ingress-ns-selector-no-pods.yml
@@ -1,0 +1,109 @@
+---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  namespace: default
+  name: macvlan1-simple
+spec: 
+  config: '{
+            "cniVersion": "0.3.1",
+            "name": "macvlan1-simple",
+            "plugins": [
+                {
+                    "type": "macvlan",
+                    "mode": "bridge",
+                    "ipam":{
+                      "type":"host-local",
+                      "subnet":"2.2.6.0/24",
+                      "rangeStart":"2.2.6.8",
+                      "rangeEnd":"2.2.6.67"
+                    }
+                }]
+        }'
+---
+# namespace for MultiNetworkPolicy 
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: test-ingress-ns-selector-no-pods
+--- 
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: test-ingress-ns-selector-no-pods-blue
+---
+# Pods
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-server
+  namespace: test-ingress-ns-selector-no-pods
+  annotations:
+    k8s.v1.cni.cncf.io/networks: default/macvlan1-simple
+  labels:
+    app: test-ingress-ns-selector-no-pods
+    name: pod-server
+spec:
+  containers:
+  - name: macvlan-worker1
+    image: ghcr.io/k8snetworkplumbingwg/multi-networkpolicy-iptables:e2e-test
+    command: ["nc", "-klp", "5555"]
+    securityContext:
+      privileged: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-client-a
+  namespace: test-ingress-ns-selector-no-pods
+  annotations:
+    k8s.v1.cni.cncf.io/networks: default/macvlan1-simple
+  labels:
+    app: test-ingress-ns-selector-no-pods
+    name: pod-client-a
+spec:
+  containers:
+  - name: macvlan-worker1
+    image: ghcr.io/k8snetworkplumbingwg/multi-networkpolicy-iptables:e2e-test
+    command: ["nc", "-klp", "5555"]
+    securityContext:
+      privileged: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-client-b
+  namespace: test-ingress-ns-selector-no-pods-blue
+  annotations:
+    k8s.v1.cni.cncf.io/networks: default/macvlan1-simple
+  labels:
+    app: test-ingress-ns-selector-no-pods
+    name: pod-client-b
+spec:
+  containers:
+  - name: macvlan-worker1
+    image: ghcr.io/k8snetworkplumbingwg/multi-networkpolicy-iptables:e2e-test
+    command: ["nc", "-klp", "5555"]
+    securityContext:
+      privileged: true
+---
+# MultiNetworkPolicies
+# this policy accepts ingress trafic from pod-client-a to pod-server
+apiVersion: k8s.cni.cncf.io/v1beta1
+kind: MultiNetworkPolicy
+metadata:
+  name: policy-test-ingress-ns-selector-no-pods
+  namespace: test-ingress-ns-selector-no-pods
+  annotations:
+    k8s.v1.cni.cncf.io/policy-for: default/macvlan1-simple
+spec:
+  podSelector:
+    matchLabels:
+      name: pod-server
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          foo: bar # No namespace with this label exists
+  policyTypes:
+  - Ingress


### PR DESCRIPTION
If a policy rule has a `from` (or `to`) selector that matches no pods, the subject pod has to not be reached by  (or has to not reach) any pods.

The following example helps clarify the reasons behind these: Given a scenario  with 3 pods (A, B, C) and a rule like:
```
podSelector:
    matchLabels:
      name: A
  ingress:
  - from:
    - podSelector:
        matchLabels:
          name: B
  policyTypes:
  - Ingress
```
Pod A can be reached only by pod B. Pod C can't reach A, and this has to be ensured even if pod B is deleted.

Add an end-to-end test case to validate this scenario and adjust unit tests accordingly.

cc @pliurh @s1061123 