### PR TITLE
e2e: Add basic bond-cni test case 

### DIFF
--- a/.github/workflows/kind-e2e.yml
+++ b/.github/workflows/kind-e2e.yml
@@ -31,16 +31,11 @@ jobs:
           # enable ip6_tables
           sudo modprobe ip6_tables
 
-          bats ./tests/*.bats
-
-      - name: Export kind logs
-        if: ${{ failure() }}
-        run:
-          ./e2e/bin/kind export logs /tmp/kind-logs
+          ./run_all_tests.sh
 
       - name: Upload logs
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: kind-logs-e2e
-          path: /tmp/kind-logs/
+          path: ./e2e/artifacts/

--- a/e2e/multi-network-policy-iptables-e2e.yml
+++ b/e2e/multi-network-policy-iptables-e2e.yml
@@ -142,6 +142,7 @@ spec:
         # uncomment if you want to accept ICMP/ICMPv6 traffic
         #- "--accept-icmp"
         #- "--accept-icmpv6"
+        - "--network-plugins=macvlan,bond"
         resources:
           requests:
             cpu: "100m"

--- a/e2e/multi-network-policy-iptables-e2e.yml
+++ b/e2e/multi-network-policy-iptables-e2e.yml
@@ -143,6 +143,7 @@ spec:
         #- "--accept-icmp"
         #- "--accept-icmpv6"
         - "--network-plugins=macvlan,bond"
+        - -v=8
         resources:
           requests:
             cpu: "100m"

--- a/e2e/run_all_tests.sh
+++ b/e2e/run_all_tests.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+E2E="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+pushd ${E2E}
+
+suite_failed=0
+
+for f in ./tests/*.bats; do
+    bats $f
+    retval=$?
+    if [ $retval -ne 0 ]; then
+        suite_failed=1
+        ./bin/kind export logs ./artifacts/`basename $f`.test/kind-logs
+    fi
+done
+
+exit $suite_failed

--- a/e2e/setup_cluster.sh
+++ b/e2e/setup_cluster.sh
@@ -30,7 +30,7 @@ kind export kubeconfig
 sleep 1
 
 # install calico
-kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/master/manifests/calico.yaml
+kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.1/manifests/calico.yaml
 kubectl -n kube-system set env daemonset/calico-node FELIX_IGNORELOOSERPF=true
 kubectl -n kube-system set env daemonset/calico-node FELIX_XDPENABLED=false
 
@@ -44,6 +44,8 @@ kubectl create -f cni-install.yml
 sleep 3
 kubectl -n kube-system wait --for=condition=ready -l name=cni-plugins pod --timeout=300s
 
+#install bond-cni
+kubectl create -f  https://raw.githubusercontent.com/k8snetworkplumbingwg/bond-cni/refs/heads/master/manifests/bond-cni.yaml
 
 # install multi-networkpolicy API
 kubectl apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/multi-networkpolicy/master/scheme.yml

--- a/e2e/tests/bond-cni.bats
+++ b/e2e/tests/bond-cni.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+setup() {
+	cd $BATS_TEST_DIRNAME
+	load "common"
+	pod_a_net1=$(get_net1_ip "bond-testing" "pod-a")
+	pod_b_net1=$(get_net1_ip "bond-testing" "pod-b")
+	pod_c_net1=$(get_net1_ip "bond-testing" "pod-c")
+}
+
+@test "setup resources" {
+	# create test manifests
+	kubectl create -f bond-cni.yml
+
+	# verify all pods are available
+	run kubectl -n bond-testing wait --for=condition=ready -l app=bond-testing pod --timeout=${kubewait_timeout}
+	[ "$status" -eq  "0" ]
+
+	# wait for sync
+	sleep 5
+}
+
+@test "bond-testing check pod-b -> pod-a" {
+	run kubectl -n bond-testing exec pod-b -- sh -c "echo x | nc -w 1 ${pod_a_net1} 5555"
+	[ "$status" -eq  "0" ]
+}
+
+@test "bond-testing check pod-c -> pod-a" {
+	run kubectl -n bond-testing exec pod-client-b -- sh -c "echo x | nc -w 1 ${pod_a_net1} 5555"
+	[ "$status" -eq  "1" ]
+}
+
+@test "bond-testing check pod-a -> pod-b" {
+	run kubectl -n bond-testing exec pod-a -- sh -c "echo x | nc -w 1 ${pod_b_net1} 5555"
+	[ "$status" -eq  "1" ]
+}
+
+@test "bond-testing check pod-a -> pod-c" {
+	run kubectl -n bond-testing exec pod-a -- sh -c "echo x | nc -w 1 ${pod_c_net1} 5555"
+	[ "$status" -eq  "0" ]
+}
+
+@test "cleanup environments" {
+	# remove test manifests
+	kubectl delete -f bond-cni.yml
+	run kubectl -n bond-testing wait --for=delete -l app=bond-testing pod --timeout=${kubewait_timeout}
+	[ "$status" -eq  "0" ]
+
+	sleep 5
+}

--- a/e2e/tests/bond-cni.yml
+++ b/e2e/tests/bond-cni.yml
@@ -1,0 +1,131 @@
+---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  namespace: default
+  name: macvlan-nad
+spec: 
+  config: '{
+            "cniVersion": "0.3.1",
+            "name": "macvlan1",
+            "type": "macvlan"
+        }'
+---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  namespace: default
+  name: bond-nad
+spec: 
+  config: '{
+            "cniVersion": "0.3.1",
+            "name": "test-nad",
+            "type": "bond",
+            "mode": "active-backup",
+            "failOverMac": 1,
+            "linksInContainer": true,
+            "miimon": "100",
+            "mtu": 1500,
+            "links": [ 
+                {"name": "link1"},
+                {"name": "link2"}
+            ],
+            "ipam":{
+              "type":"host-local",
+              "subnet":"2.2.6.0/24",
+              "rangeStart":"2.2.6.8",
+              "rangeEnd":"2.2.6.67"
+            }
+        }'
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: bond-testing
+---
+# Pods
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-a
+  namespace: bond-testing
+  annotations:
+    k8s.v1.cni.cncf.io/networks: '[
+      {"name": "macvlan-nad", "namespace":"default", "interface": "link1"},
+      {"name": "macvlan-nad", "namespace":"default", "interface": "link2"},
+      {"name": "bond-nad", "namespace":"default", "interface": "net1"}]'
+  labels:
+    app: bond-testing
+    name: pod-a
+spec:
+  containers:
+  - name: macvlan-worker1
+    image: ghcr.io/k8snetworkplumbingwg/multi-networkpolicy-iptables:e2e-test
+    command: ["nc", "-klp", "5555"]
+    securityContext:
+      privileged: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-b
+  namespace: bond-testing
+  annotations:
+    k8s.v1.cni.cncf.io/networks: '[
+      {"name": "macvlan-nad", "namespace":"default", "interface": "link1"},
+      {"name": "macvlan-nad", "namespace":"default", "interface": "link2"},
+      {"name": "bond-nad", "namespace":"default", "interface": "net1"}]'
+  labels:
+    app: bond-testing
+    name: pod-b
+spec:
+  containers:
+  - name: macvlan-worker1
+    image: ghcr.io/k8snetworkplumbingwg/multi-networkpolicy-iptables:e2e-test
+    command: ["nc", "-klp", "5555"]
+    securityContext:
+      privileged: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-c
+  namespace: bond-testing
+  annotations:
+    k8s.v1.cni.cncf.io/networks: '[
+      {"name": "macvlan-nad", "namespace":"default", "interface": "link1"},
+      {"name": "macvlan-nad", "namespace":"default", "interface": "link2"},
+      {"name": "bond-nad", "namespace":"default", "interface": "net1"}]'
+  labels:
+    app: bond-testing
+    name: pod-c
+spec:
+  containers:
+  - name: macvlan-worker1
+    image: ghcr.io/k8snetworkplumbingwg/multi-networkpolicy-iptables:e2e-test
+    command: ["nc", "-klp", "5555"]
+    securityContext:
+      privileged: true
+---
+# MultiNetworkPolicies
+apiVersion: k8s.cni.cncf.io/v1beta1
+kind: MultiNetworkPolicy
+metadata:
+  name: test-multinetwork-policy-bond
+  namespace: bond-testing
+  annotations:
+    k8s.v1.cni.cncf.io/policy-for: default/bond-nad
+spec:
+  podSelector:
+    matchLabels:
+      name: pod-a
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          name: pod-b
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          name: pod-c

--- a/e2e/tests/ipblock-list.bats
+++ b/e2e/tests/ipblock-list.bats
@@ -18,6 +18,8 @@ setup() {
 	kubectl create -f ipblock-list.yml
 	run kubectl -n test-ipblock-list wait --for=condition=ready -l app=test-ipblock-list pod --timeout=${kubewait_timeout}
 	[ "$status" -eq  "0" ]
+
+	sleep 3
 }
 
 @test "test-ipblock-list check client-a" {

--- a/e2e/tests/ipblock-stacked.bats
+++ b/e2e/tests/ipblock-stacked.bats
@@ -18,6 +18,8 @@ setup() {
 	kubectl create -f ipblock-stacked.yml
 	run kubectl -n test-ipblock-stacked wait --for=condition=ready -l app=test-ipblock-stacked pod --timeout=${kubewait_timeout}
 	[ "$status" -eq  "0" ]
+
+	sleep 3
 }
 
 @test "check generated iptables rules" {

--- a/e2e/tests/ipblock.bats
+++ b/e2e/tests/ipblock.bats
@@ -18,6 +18,8 @@ setup() {
 	kubectl create -f ipblock.yml
 	run kubectl -n test-ipblock wait --for=condition=ready -l app=test-ipblock pod --timeout=${kubewait_timeout}
 	[ "$status" -eq  "0" ]
+
+	sleep 3
 }
 
 @test "check generated iptables rules" {

--- a/pkg/server/policyrules.go
+++ b/pkg/server/policyrules.go
@@ -151,6 +151,9 @@ func (ipt *iptableBuffer) SaveRules(path string) error {
 }
 
 func (ipt *iptableBuffer) SyncRules(iptables utiliptables.Interface) error {
+	if klog.V(4) {
+		klog.Infof("SyncRules\n%s\n", ipt.filterRules.String())
+	}
 	return iptables.RestoreAll(ipt.filterRules.Bytes(), utiliptables.NoFlushTables, utiliptables.RestoreCounters)
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -551,7 +551,7 @@ func (s *Server) generatePolicyRulesForPod(pod *v1.Pod, podInfo *controllers.Pod
 }
 
 func (s *Server) generatePolicyRulesForPodAndFamily(pod *v1.Pod, podInfo *controllers.PodInfo, iptables utiliptables.Interface) error {
-	klog.V(8).Infof("Generate rules for Pod: %v/%v\n", podInfo.Namespace, podInfo.Name)
+	klog.V(4).Infof("Generate rules for Pod: %v/%v\n", podInfo.Namespace, podInfo.Name)
 	// -t filter -N MULTI-INGRESS # ensure chain
 	iptables.EnsureChain(utiliptables.TableFilter, ingressChain)
 	// -t filter -N MULTI-EGRESS # ensure chain


### PR DESCRIPTION
Update `setup_cluster.sh` to create needed resources
for the bond-cni plugin.

Configure MultiNetworkpolicy iptables daemon to handle
bond NetworkAttachmentDefinitions.

Verify ingress/egress scenarios works for `bond` network types.
