### PR TITLE
e2e: Avoid checking the number of iptables file

### DIFF
--- a/e2e/tests/ingress-ns-selector-no-pods.bats
+++ b/e2e/tests/ingress-ns-selector-no-pods.bats
@@ -53,11 +53,4 @@ setup() {
 	kubectl delete -f ingress-ns-selector-no-pods.yml
 	run kubectl -n test-ingress-ns-selector-no-pods wait --for=delete -l app=test-ingress-ns-selector-no-pods pod --timeout=${kubewait_timeout}
 	[ "$status" -eq  "0" ]
-
-	sleep 3
-	# check that no iptables files in pod-iptables
-	pod_name=$(kubectl -n kube-system get pod -o wide | grep 'kind-worker' | grep multi-net | cut -f 1 -d ' ')
-	run kubectl -n kube-system exec ${pod_name} -- \
-		sh -c "find /var/lib/multi-networkpolicy/iptables/ -name '*.iptables' | wc -l"
-        [ "$output" = "0" ]
 }

--- a/e2e/tests/simple-v4-egress.bats
+++ b/e2e/tests/simple-v4-egress.bats
@@ -34,14 +34,6 @@ setup() {
 	# check pod-client-b has NO multi-networkpolicy iptables rules for ingress
         run kubectl -n test-simple-v4-egress exec pod-client-b -- sh -c "iptables-save | grep MULTI-0-EGRESS"
 	[ "$status" -eq  "1" ]
-
-	# wait for sync
-	sleep 5
-	# check that iptables files in pod-iptables
-	pod_name=$(kubectl -n kube-system get pod -o wide | grep 'kind-worker' | grep multi-net | cut -f 1 -d ' ')
-	run kubectl -n kube-system exec ${pod_name} -- \
-		sh -c "find /var/lib/multi-networkpolicy/iptables/ -name '*.iptables' | wc -l"
-        [ "$output" = "6" ]
 }
 
 @test "test-simple-v4-egress check client-a -> server" {
@@ -89,11 +81,4 @@ setup() {
 	kubectl delete -f simple-v4-egress.yml
 	run kubectl -n test-simple-v4-egress wait --for=delete -l app=test-simple-v4-egress pod --timeout=${kubewait_timeout}
 	[ "$status" -eq  "0" ]
-
-	sleep 5
-	# check that no iptables files in pod-iptables
-	pod_name=$(kubectl -n kube-system get pod -o wide | grep 'kind-worker' | grep multi-net | cut -f 1 -d ' ')
-	run kubectl -n kube-system exec ${pod_name} -- \
-		sh -c "find /var/lib/multi-networkpolicy/iptables/ -name '*.iptables' | wc -l"
-        [ "$output" = "0" ]
 }

--- a/e2e/tests/simple-v4-ingress.bats
+++ b/e2e/tests/simple-v4-ingress.bats
@@ -34,14 +34,6 @@ setup() {
 	# check pod-client-b has NO multi-networkpolicy iptables rules for ingress
         run kubectl -n test-simple-v4-ingress exec pod-client-b -- sh -c "iptables-save | grep MULTI-0-INGRESS"
 	[ "$status" -eq  "1" ]
-
-	# wait for sync
-	sleep 5
-	# check that iptables files in pod-iptables
-	pod_name=$(kubectl -n kube-system get pod -o wide | grep 'kind-worker' | grep multi-net | cut -f 1 -d ' ')
-	run kubectl -n kube-system exec ${pod_name} -- \
-		sh -c "find /var/lib/multi-networkpolicy/iptables/ -name '*.iptables' | wc -l"
-        [ "$output" = "6" ]
 }
 
 @test "test-simple-v4-ingress check client-a -> server" {
@@ -89,11 +81,4 @@ setup() {
 	kubectl delete -f simple-v4-ingress.yml
 	run kubectl -n test-simple-v4-ingress wait --for=delete -l app=test-simple-v4-ingress pod --timeout=${kubewait_timeout}
 	[ "$status" -eq  "0" ]
-
-	sleep 5
-	# check that no iptables files in pod-iptables
-	pod_name=$(kubectl -n kube-system get pod -o wide | grep 'kind-worker' | grep multi-net | cut -f 1 -d ' ')
-	run kubectl -n kube-system exec ${pod_name} -- \
-		sh -c "find /var/lib/multi-networkpolicy/iptables/ -name '*.iptables' | wc -l"
-        [ "$output" = "0" ]
 }

--- a/e2e/tests/simple-v6-ingress.bats
+++ b/e2e/tests/simple-v6-ingress.bats
@@ -36,12 +36,6 @@ setup() {
 	# check pod-client-b has NO multi-networkpolicy ip6tables rules for ingress
         run kubectl -n test-simple-v6-ingress exec pod-client-b -- sh -c "ip6tables-save | grep MULTI-0-INGRESS"
 	[ "$status" -eq  "1" ]
-
-	# check that ip6tables files in pod-iptables
-	pod_name=$(kubectl -n kube-system get pod -o wide | grep 'kind-worker' | grep multi-net | cut -f 1 -d ' ')
-	run kubectl -n kube-system exec ${pod_name} -- \
-		sh -c "find /var/lib/multi-networkpolicy/iptables/ -name '*.ip6tables' | wc -l"
-        [ "$output" = "6" ]
 }
 
 @test "test-simple-v6-ingress check client-a -> server" {
@@ -89,11 +83,4 @@ setup() {
 	kubectl delete -f simple-v6-ingress.yml
 	run kubectl -n test-simple-v6-ingress wait --for=delete -l app=test-simple-v6-ingress pod --timeout=${kubewait_timeout}
 	[ "$status" -eq  "0" ]
-
-	sleep 3
-	# check that no ip6tables files in pod-iptables
-	pod_name=$(kubectl -n kube-system get pod -o wide | grep 'kind-worker' | grep multi-net | cut -f 1 -d ' ')
-	run kubectl -n kube-system exec ${pod_name} -- \
-		sh -c "find /var/lib/multi-networkpolicy/iptables/ -name '*.ip6tables' | wc -l"
-        [ "$output" = "0" ]
 }


### PR DESCRIPTION
Checking the number of files in `/var/lib/multi-networkpolicy/iptables/` brings to a number of test flakes in GitHub CI lanes. This flakes are not reproducible in local development environments, therefore they are likely due to a low resource system.

Beside these checks can flake, the component under test behavior looks good from the assertion point of view, which is the meaningful part for the these tests.

Remove any verification about the `/var/lib/multi-networkpolicy/iptables/` folder in e2e tests