### PR TITLE
deps: bump `golang.org/x/net`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/net v0.20.0 // indirect
+	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/oauth2 v0.16.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/term v0.15.0 // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -220,7 +220,7 @@ github.com/spf13/pflag
 # golang.org/x/mod v0.14.0
 ## explicit; go 1.18
 golang.org/x/mod/semver
-# golang.org/x/net v0.20.0 => golang.org/x/net v0.17.0
+# golang.org/x/net v0.41.0 => golang.org/x/net v0.17.0
 ## explicit; go 1.17
 golang.org/x/net/context
 golang.org/x/net/html


### PR DESCRIPTION
CVE-2024-45338

```
$ go get -u golang.org/x/net
go: downloading golang.org/x/net v0.17.0
go: upgraded golang.org/x/net v0.20.0 => v0.39.0

$ go mod tidy
$ go mod vendor
```