### PR TITLE
Give precendence to IPBlock field over PodSelector

### DIFF
--- a/pkg/server/policyrules.go
+++ b/pkg/server/policyrules.go
@@ -293,13 +293,13 @@ func (ipt *iptableBuffer) renderIngressFrom(s *Server, podInfo *controllers.PodI
 
 	s.podMap.Update(s.podChanges)
 	for _, peer := range from {
-		if peer.PodSelector != nil || peer.NamespaceSelector != nil {
-			ipt.renderIngressFromSelector(s, podInfo, chainName, peer, policyNetworks)
+		if peer.IPBlock != nil {
+			ipt.renderIngressFromIPBlock(podInfo, chainName, peer, policyNetworks)
 			continue
 		}
 
-		if peer.IPBlock != nil {
-			ipt.renderIngressFromIPBlock(podInfo, chainName, peer, policyNetworks)
+		if peer.PodSelector != nil || peer.NamespaceSelector != nil {
+			ipt.renderIngressFromSelector(s, podInfo, chainName, peer, policyNetworks)
 			continue
 		}
 
@@ -537,13 +537,13 @@ func (ipt *iptableBuffer) renderEgressTo(s *Server, podInfo *controllers.PodInfo
 
 	s.podMap.Update(s.podChanges)
 	for _, peer := range to {
-		if peer.PodSelector != nil || peer.NamespaceSelector != nil {
-			ipt.renderEgressToSelector(s, podInfo, chainName, peer, policyNetworks)
+		if peer.IPBlock != nil {
+			ipt.renderEgressToIPBlock(podInfo, chainName, peer, policyNetworks)
 			continue
 		}
 
-		if peer.IPBlock != nil {
-			ipt.renderEgressToIPBlock(podInfo, chainName, peer, policyNetworks)
+		if peer.PodSelector != nil || peer.NamespaceSelector != nil {
+			ipt.renderEgressToSelector(s, podInfo, chainName, peer, policyNetworks)
 			continue
 		}
 

--- a/pkg/server/policyrules_test.go
+++ b/pkg/server/policyrules_test.go
@@ -2041,7 +2041,6 @@ COMMIT
 		s.ip4Tables = result
 
 		s.generatePolicyRulesForPod(pod1, podInfo1)
-		fmt.Println(result.Dump.String())
 		Expect(result.Dump.String()).To(Equal(`*nat
 :PREROUTING - [0:0]
 :INPUT - [0:0]
@@ -2087,6 +2086,140 @@ COMMIT
 -A MULTI-0-EGRESS -m mark --mark 0x30000/0x30000 -j RETURN
 -A MULTI-0-EGRESS-0-PORTS -o net1 -m tcp -p tcp  -j MARK --set-xmark 0x10000/0x10000
 -A MULTI-0-EGRESS-0-TO -m comment --comment "no egress to, skipped" -j MARK --set-xmark 0x20000/0x20000
+COMMIT
+*mangle
+COMMIT
+`))
+
+	})
+
+	It("ignore `podSelector` and `namespaceSelector` when IPBlock field is set", func() {
+		policy1 := &multiv1beta1.MultiNetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ipblock-override-policy",
+				Namespace: "testns1",
+				Annotations: map[string]string{
+					PolicyNetworkAnnotation: "net-attach1",
+				},
+			},
+			Spec: multiv1beta1.MultiNetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"role": "targetpod",
+					},
+				},
+				Ingress: []multiv1beta1.MultiNetworkPolicyIngressRule{{
+					From: []multiv1beta1.MultiNetworkPolicyPeer{{
+						IPBlock: &multiv1beta1.IPBlock{
+							CIDR:   "1.1.1.0/16",
+							Except: []string{"1.1.1.1"},
+						},
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"tobe": "ignored"},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"tobe": "ignored"},
+						},
+					}},
+				}},
+				Egress: []multiv1beta1.MultiNetworkPolicyEgressRule{{
+					To: []multiv1beta1.MultiNetworkPolicyPeer{{
+						IPBlock: &multiv1beta1.IPBlock{
+							CIDR:   "2.2.2.0/16",
+							Except: []string{"2.2.2.2"},
+						},
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"tobe": "ignored"},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"tobe": "ignored"},
+						},
+					}},
+				}},
+			},
+		}
+
+		s := NewFakeServer("samplehost")
+		Expect(s).NotTo(BeNil())
+
+		AddNamespace(s, "testns1")
+
+		Expect(
+			s.netdefChanges.Update(nil, NewNetDef("testns1", "net-attach1", NewCNIConfig("testCNI", "multi"))),
+		).To(BeTrue())
+
+		pod1 := NewFakePodWithNetAnnotation(
+			"testns1",
+			"testpod1",
+			"net-attach1",
+			NewFakeNetworkStatus("testns1", "net-attach1", "192.168.1.1", "10.1.1.1"),
+			map[string]string{
+				"role": "targetpod",
+			})
+		pod1.Spec.NodeName = "samplehost"
+
+		AddPod(s, pod1)
+		podInfo1, err := s.podMap.GetPodInfo(pod1)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(
+			s.policyChanges.Update(nil, policy1),
+		).To(BeTrue())
+		s.policyMap.Update(s.policyChanges)
+
+		result := fakeiptables.NewFake()
+		s.ip4Tables = result
+
+		s.generatePolicyRulesForPod(pod1, podInfo1)
+		Expect(result.Dump.String()).To(Equal(`*nat
+:PREROUTING - [0:0]
+:INPUT - [0:0]
+:OUTPUT - [0:0]
+:POSTROUTING - [0:0]
+-A PREROUTING -i net1 -j RETURN
+COMMIT
+*filter
+:INPUT - [0:0]
+:FORWARD - [0:0]
+:OUTPUT - [0:0]
+:MULTI-INGRESS - [0:0]
+:MULTI-EGRESS - [0:0]
+:MULTI-INGRESS-COMMON - [0:0]
+:MULTI-EGRESS-COMMON - [0:0]
+:MULTI-0-INGRESS - [0:0]
+:MULTI-0-INGRESS-0-PORTS - [0:0]
+:MULTI-0-INGRESS-0-FROM - [0:0]
+:MULTI-0-EGRESS - [0:0]
+:MULTI-0-EGRESS-0-PORTS - [0:0]
+:MULTI-0-EGRESS-0-TO - [0:0]
+-A INPUT -i net1 -j MULTI-INGRESS
+-A OUTPUT -o net1 -j MULTI-EGRESS
+-A MULTI-INGRESS -j MULTI-INGRESS-COMMON
+-A MULTI-INGRESS -m comment --comment "policy:ipblock-override-policy net-attach-def:testns1/net-attach1" -i net1 -j MULTI-0-INGRESS
+-A MULTI-INGRESS -m mark --mark 0x30000/0x30000 -j RETURN
+-A MULTI-INGRESS -j DROP
+-A MULTI-EGRESS -j MULTI-EGRESS-COMMON
+-A MULTI-EGRESS -m comment --comment "policy:ipblock-override-policy net-attach-def:testns1/net-attach1" -o net1 -j MULTI-0-EGRESS
+-A MULTI-EGRESS -m mark --mark 0x30000/0x30000 -j RETURN
+-A MULTI-EGRESS -j DROP
+-A MULTI-INGRESS-COMMON -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A MULTI-EGRESS-COMMON -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A MULTI-0-INGRESS -j MARK --set-xmark 0x0/0x30000
+-A MULTI-0-INGRESS -j MULTI-0-INGRESS-0-PORTS
+-A MULTI-0-INGRESS -j MULTI-0-INGRESS-0-FROM
+-A MULTI-0-INGRESS -m mark --mark 0x30000/0x30000 -j RETURN
+-A MULTI-0-INGRESS-0-PORTS -m comment --comment "no ingress ports, skipped" -j MARK --set-xmark 0x10000/0x10000
+-A MULTI-0-INGRESS-0-FROM -i net1 -s 1.1.1.1 -j DROP
+-A MULTI-0-INGRESS-0-FROM -i net1 -s 1.1.1.0/16 -j MARK --set-xmark 0x20000/0x20000
+-A MULTI-0-INGRESS-0-FROM -i net1 -s 10.1.1.1 -j MARK --set-xmark 0x20000/0x20000
+-A MULTI-0-EGRESS -j MARK --set-xmark 0x0/0x30000
+-A MULTI-0-EGRESS -j MULTI-0-EGRESS-0-PORTS
+-A MULTI-0-EGRESS -j MULTI-0-EGRESS-0-TO
+-A MULTI-0-EGRESS -m mark --mark 0x30000/0x30000 -j RETURN
+-A MULTI-0-EGRESS-0-PORTS -m comment --comment "no egress ports, skipped" -j MARK --set-xmark 0x10000/0x10000
+-A MULTI-0-EGRESS-0-TO -o net1 -d 2.2.2.2 -j DROP
+-A MULTI-0-EGRESS-0-TO -o net1 -d 2.2.2.0/16 -j MARK --set-xmark 0x20000/0x20000
+-A MULTI-0-EGRESS-0-TO -o net1 -d 10.1.1.1 -j MARK --set-xmark 0x20000/0x20000
 COMMIT
 *mangle
 COMMIT


### PR DESCRIPTION
As per API description [1]:
> IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be."

if a policy rule has a from/to rule with an IPBlock field,
then the PodSelector and NamespaceSelector fields must be ignored.

[1] https://github.com/k8snetworkplumbingwg/multi-networkpolicy/blob/master/scheme.yml#L88

this PR also contains a refactor around `renderIngressFrom` and `renderEgressTo`.